### PR TITLE
Change the `generate` code to check if a tensor, not specifically a torch.FloatTensor.

### DIFF
--- a/spear_tts_pytorch/spear_tts_pytorch.py
+++ b/spear_tts_pytorch/spear_tts_pytorch.py
@@ -606,7 +606,7 @@ class TextToSemantic(Module):
         assert cond_scale >= 1.
         assert not (cond_scale > 1 and self.cond_drop_prob == 0), 'you need to train with conditional drop probability greater than 0 to use classifier free guidance at inference, and it needs to be the right source to target pair'
 
-        if isinstance(source, (FloatTensor)) and source_type == 'speech':
+        if torch.is_tensor(source) and source_type == 'speech':
             assert exists(self.wav2vec), 'wav2vec should be passed in, if generating with source as raw soundwave'
             source = self.wav2vec(source)
 


### PR DESCRIPTION
The very specific check prevents the DatasetGenerator from running on the GPU.

Before this change:

```
RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but got torch.cuda.FloatTensor instead (while checking arguments for embedding)
```

This was due to the wav2vec being skipped, leading to the audio data being passed through. You could run this code on the CPU, but it takes much longer.

This allows moving the process to the GPU.